### PR TITLE
Actually...

### DIFF
--- a/httpd-cfg/01-custom.conf
+++ b/httpd-cfg/01-custom.conf
@@ -9,9 +9,8 @@
     RewriteRule (.*) https://www.openshift.tv/$1 [NE,L,R=301]
 
     RewriteCond  %{HTTP_HOST}  ^www\.openshift\.tv$
-    RewriteRule ^$ https://www.openshift.com/streaming [NE,L,R=301]
+    RewriteRule ^$ https://www.twitch.tv/redhatopenshift [NE,L,R=301]
     RewriteRule ^youtube/?(.*) https://www.youtube.com/user/rhopenshift/$1 [NE,L,R=301]
-    RewriteRule ^facebook/?(.*) https://www.facebook.com/openshift/$1 [NE,L,R=301]
     RewriteRule ^twitch/?(.*) https://www.twitch.tv/redhatopenshift/$1 [NE,L,R=301]
 
   </Directory>


### PR DESCRIPTION
After some discussion in [#streaming on CoreOS Slack](https://coreos.slack.com/archives/C01456K7G2H/p1631808706053900), the redirect for openshift.tv users should go directly to Twitch for a better user experience.