### PR TITLE
redirect to RH Livestreaming page

### DIFF
--- a/httpd-cfg/01-custom.conf
+++ b/httpd-cfg/01-custom.conf
@@ -9,7 +9,7 @@
     RewriteRule (.*) https://www.openshift.tv/$1 [NE,L,R=301]
 
     RewriteCond  %{HTTP_HOST}  ^www\.openshift\.tv$
-    RewriteRule ^$ https://www.twitch.tv/redhatopenshift [NE,L,R=301]
+    RewriteRule ^$ https://www.redhat.com/en/livestreaming [NE,L,R=301]
     RewriteRule ^youtube/?(.*) https://www.youtube.com/user/rhopenshift/$1 [NE,L,R=301]
     RewriteRule ^twitch/?(.*) https://www.twitch.tv/redhatopenshift/$1 [NE,L,R=301]
 


### PR DESCRIPTION
RH page has been updated, so let's pull it back to the corporate page rather than Twitch as the default